### PR TITLE
Fix WKWebView with embedded iframe

### DIFF
--- a/src/webview-utils.ios.ts
+++ b/src/webview-utils.ios.ts
@@ -29,7 +29,7 @@ class WebviewUtilsWKNavigationDelegateImpl extends NSObject implements WKNavigat
     });
 
     if (isHttpRequest && !areHeadersAdded) {
-      if (navigationAction.request.HTTPMethod !== "GET") {
+      if (navigationAction.request.HTTPMethod !== "GET" || !navigationAction.targetFrame.mainFrame) {
         decisionHandler(WKNavigationActionPolicy.Allow);
         return;
       }


### PR DESCRIPTION
before fix - main frame on load navigated to iframe url

now - if webview has iframe - its will be ignored

--------------
steps to reproduce
add headers to url with embedded iframe for example https://yambr.ru/test/

----
some screenshots before and after fix

1.  before module is redirecting to embedded iframe
![photo_2021-05-11_00-13-08](https://user-images.githubusercontent.com/28951082/117725739-46050900-b1ee-11eb-81e0-6faf13fc69d4.jpg)
2. add some code to js library
![photo_2021-05-11_00-13-14](https://user-images.githubusercontent.com/28951082/117726002-97ad9380-b1ee-11eb-97b8-028bc1e3600d.jpg)
3. fixed!
![photo_2021-05-11_00-06-44](https://user-images.githubusercontent.com/28951082/117726019-a005ce80-b1ee-11eb-872b-ee923dd23906.jpg)






